### PR TITLE
Update upstream

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/kdoc/KDocRenderer.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/kdoc/KDocRenderer.kt
@@ -163,7 +163,9 @@ object KDocRenderer {
         // Avoid wrapping the entire converted contents in a <p> tag if it's just a single paragraph
         val maybeSingleParagraph = markdownNode.children.singleOrNull { it.type != MarkdownTokenTypes.EOL }
         return if (maybeSingleParagraph != null && !allowSingleParagraph) {
-            maybeSingleParagraph.children.joinToString("") { it.toHtml() }
+            maybeSingleParagraph.children.joinToString("") {
+                if (it.text == "\n") " " else it.toHtml()
+            }
         }
         else {
             markdownNode.toHtml()

--- a/idea/testData/editor/quickDoc/OnMethodUsageWithMultilineParam.kt
+++ b/idea/testData/editor/quickDoc/OnMethodUsageWithMultilineParam.kt
@@ -1,0 +1,16 @@
+/**
+ * Some documentation
+ * on two lines.
+ *
+ * @param test String
+ * on two lines
+ */
+fun testMethod(test: String) {
+}
+
+fun test() {
+    <caret>testMethod("")
+}
+
+//INFO: <pre><b>public</b> <b>fun</b> testMethod(test: String): Unit <i>defined in</i> root package <i>in file</i> OnMethodUsageWithMultilineParam.kt</pre><p>Some documentation on two lines.</p>
+//INFO: <dl><dt><b>Parameters:</b></dt><dd><code>test</code> - String on two lines</dd></dl>

--- a/idea/tests/org/jetbrains/kotlin/idea/editor/quickDoc/QuickDocProviderTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/editor/quickDoc/QuickDocProviderTestGenerated.java
@@ -258,6 +258,12 @@ public class QuickDocProviderTestGenerated extends AbstractQuickDocProviderTest 
         doTest(fileName);
     }
 
+    @TestMetadata("OnMethodUsageWithMultilineParam.kt")
+    public void testOnMethodUsageWithMultilineParam() throws Exception {
+        String fileName = KotlinTestUtils.navigationMetadata("idea/testData/editor/quickDoc/OnMethodUsageWithMultilineParam.kt");
+        doTest(fileName);
+    }
+
     @TestMetadata("OnMethodUsageWithReceiver.kt")
     public void testOnMethodUsageWithReceiver() throws Exception {
         String fileName = KotlinTestUtils.navigationMetadata("idea/testData/editor/quickDoc/OnMethodUsageWithReceiver.kt");


### PR DESCRIPTION
… (#1459)

* KT-21213 multiline kdoc - intellij joins lines together without space

* Use \n directly as a line separator #KT-21213

* Remove unused import #KT-21213