### PR TITLE
Update upstream

### DIFF
--- a/build-common/build.gradle.kts
+++ b/build-common/build.gradle.kts
@@ -18,7 +18,6 @@ dependencies {
     testCompile(protobufFull())
     testCompile(projectDist(":kotlin-stdlib"))
     testCompileOnly(ideaSdkDeps("openapi"))
-    testRuntime(projectDist(":kotlin-compiler"))
     testRuntime(projectDist(":kotlin-reflect"))
 }
 

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -57,7 +57,6 @@ dependencies {
     testCompile(ideaSdkDeps("openapi", "idea", "util", "asm-all", "commons-httpclient-3.1-patched"))
 
     testRuntime(projectDist(":kotlin-reflect"))
-    testRuntime(projectDist(":kotlin-compiler"))
     testRuntime(projectDist(":kotlin-daemon-client"))
     testRuntime(preloadedDeps("dx", subdir = "android-5.0/lib"))
     testRuntime(ideaSdkCoreDeps("*.jar"))

--- a/idea/idea-android/build.gradle.kts
+++ b/idea/idea-android/build.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     testCompile(commonDep("junit:junit"))
 
     testRuntime(projectDist(":kotlin-reflect"))
-    testRuntime(projectDist(":kotlin-compiler"))
     testRuntime(project(":plugins:android-extensions-ide"))
     testRuntime(project(":plugins:kapt3-idea"))
     testRuntime(project(":sam-with-receiver-ide-plugin"))

--- a/j2k/build.gradle.kts
+++ b/j2k/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     testCompile(project(":compiler:light-classes"))
     testCompile(projectDist(":kotlin-test:kotlin-test-junit"))
     testCompile(commonDep("junit:junit"))
-    testRuntime(projectDist(":kotlin-compiler"))
     testRuntime(project(":idea:idea-jvm"))
     testRuntime(project(":idea:idea-android"))
     testRuntime(project(":plugins:android-extensions-ide"))

--- a/js/js.tests/build.gradle.kts
+++ b/js/js.tests/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
     testCompile(commonDep("junit:junit"))
     testCompile(projectTests(":kotlin-build-common"))
     testCompile(projectTests(":generators:test-generator"))
-    testRuntime(projectDist(":kotlin-compiler"))
     testRuntime(projectDist(":kotlin-stdlib"))
     testRuntime(projectDist(":kotlin-stdlib-js"))
     testRuntime(projectDist(":kotlin-test:kotlin-test-js")) // to be sure that kotlin-test-js built before tests runned


### PR DESCRIPTION
This dependency makes IDEA reindex kotlin-compiler.jar after every
Gradle build, which takes time and breaks some key IDE features